### PR TITLE
Support `ActionController::Parameters`

### DIFF
--- a/lib/paraphrase/params_filter.rb
+++ b/lib/paraphrase/params_filter.rb
@@ -17,14 +17,14 @@ module Paraphrase
   # can be re-opened inside the {Query} class definition or by calling the
   # {Query.param param} class method.
   class ParamsFilter
-    attr_reader :params, :result
+    def initialize(params, keys)
+      @keys = keys
+      @params = params
+    end
 
-    def initialize(unfiltered_params, keys)
-      @params = unfiltered_params.with_indifferent_access.slice(*keys)
-
-      @result = keys.inject(HashWithIndifferentAccess.new) do |result, key|
-        value = respond_to?(key) ? send(key) : @params[key]
-        value = scrub(value)
+    def result
+      @keys.inject(ActiveSupport::HashWithIndifferentAccess.new) do |result, key|
+        value = scrub(public_send(key))
 
         if value.present?
           result[key] = value
@@ -32,6 +32,14 @@ module Paraphrase
 
         result
       end
+    end
+
+    def [](key)
+      @params[key.to_sym] || @params[key.to_s]
+    end
+
+    def params
+      self
     end
 
     private

--- a/lib/paraphrase/query.rb
+++ b/lib/paraphrase/query.rb
@@ -3,7 +3,6 @@ require 'active_support/core_ext/class/attribute'
 require 'active_support/core_ext/module/delegation'
 require 'active_support/core_ext/string/inflections'
 require 'active_support/core_ext/array/extract_options'
-require 'active_support/hash_with_indifferent_access'
 
 require 'paraphrase/active_model'
 require 'paraphrase/mapping'
@@ -68,6 +67,10 @@ module Paraphrase
 
       keys.each do |key|
         define_method(key) { params[key] }
+
+        params_filter.class_eval do
+          define_method(key) { params[key] }
+        end
       end
     end
 

--- a/spec/paraphrase/query_spec.rb
+++ b/spec/paraphrase/query_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'action_view/test_case'
+require "action_controller/metal/strong_parameters"
 
 module Paraphrase
   describe Query do
@@ -153,6 +154,19 @@ module Paraphrase
       expect(result).to include red_post
       expect(result).not_to include blue_post
       expect(result).not_to include green_post
+    end
+
+    it "works with ActionController::Parameters" do
+      query = PostQuery.new(ActionController::Parameters.new(title: "D3 How-To"))
+
+      expect(query.params).to have_key "title"
+    end
+
+    it "handles symbol or string keys when filtering params" do
+      query = PostQuery.new(title: "Top 10", "authors" => "Andre")
+
+      expect(query.params[:title]).to eq "Top 10"
+      expect(query.params[:authors]).to eq "Andre"
     end
 
     describe 'is action view compliant' do


### PR DESCRIPTION
Remove filtering keys not in `keys` argument from `unfiltered_params`
using `#slice`. Since `keys` is being iterated over, only those values
will be in the resulting hash.

Handle indifferent access for the hash-like object passed to
`ParamsFilter` by defining `ParamsFilter#params` to return itself and
define its `#[]` to check `@params` for the symbol or string versions of
the key. `ActionController::Parameters#with_indifferent_access` is
deprecated in Rails 5 and removed in Rails 5.1. It can be converted to
an `ActiveSupport::HashWithIndifferentAccess` using `#to_h` after
calling `permit` to specify what keys to keep.  If `permit` is not
called, an empty `ActiveSupport::HashWithIndifferentAccess` is returned.

Misc:
* Change `Paraphrase::ParamsFilter#result` to a method; stop memoizing it.
* When defining keys through `Query.map`, define the default method on
  the `ParamsFilter` subclass of the `Query` subclass removing the need
  for a `respond_to?` check when filtering params.